### PR TITLE
`reinterpret_array` for pointer types

### DIFF
--- a/include/enoki/array_router.h
+++ b/include/enoki/array_router.h
@@ -366,7 +366,8 @@ ENOKI_INLINE auto select(const T1 &m, const T2 &t, const T3 &f) {
                   (detail::ref_cast_t<T3, Output>) f);
 }
 
-template <typename Target, typename Source, std::enable_if_t<std::is_same<Source, Target>::value, int> = 0>
+template <typename Target, typename Source,
+          std::enable_if_t<std::is_same<Source, Target>::value, int> = 0>
 ENOKI_INLINE Target reinterpret_array(const Source &src) {
     return src;
 }
@@ -385,16 +386,20 @@ ENOKI_INLINE Target reinterpret_array(const Source &src) {
     using SrcInt = typename detail::type_chooser<sizeof(Source)>::Int;
     using TrgInt = typename detail::type_chooser<sizeof(Target)>::Int;
     if (std::is_same<Target, bool>::value)
-        return memcpy_cast<SrcInt>(src) != 0 ? Target(true) : Target(false);
-    else
-        return memcpy_cast<Target>(memcpy_cast<SrcInt>(src) != 0 ? TrgInt(-1) : TrgInt(0));
+        return enoki::memcpy_cast<SrcInt>(src) != 0 ? Target(true) : Target(false);
+    else {
+        return enoki::memcpy_cast<Target>(
+            enoki::memcpy_cast<SrcInt>(src) != 0 ? TrgInt(-1) : TrgInt(0));
+    }
 }
 
 template <typename Target, typename Source,
-          std::enable_if_t<std::is_scalar<Source>::value && std::is_scalar<Target>::value &&
-                           !std::is_same<Source, Target>::value && sizeof(Source) == sizeof(Target), int> = 0>
+          std::enable_if_t<(std::is_scalar<Source>::value || std::is_pointer<Source>::value) &&
+                           (std::is_scalar<Target>::value || std::is_pointer<Target>::value) &&
+                           !std::is_same<Source, Target>::value &&
+                           sizeof(Source) == sizeof(Target), int> = 0>
 ENOKI_INLINE Target reinterpret_array(const Source &src) {
-    return memcpy_cast<Target>(src);
+    return enoki::memcpy_cast<Target>(src);
 }
 
 template <typename T1, typename T2,

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -478,15 +478,6 @@ ENOKI_TEST_ALL(test26_mask_op) {
     );
 }
 
-ENOKI_TEST_ALL(test27_mask_from_int) {
-    mask_t<T> m1(true), m2(true | true), m3(true & false);
-    assert(all_nested(m1) && all_nested(m2) && none_nested(m3));
-    assert(all_nested(eq(m1, m2)) && none_nested(eq(m2, m3)));
-    assert(all(eq(T(1.0f), select(m1, T(1.0f), T(0.0f)))));
-    assert(all(eq(T(1.0f), select(m2, T(1.0f), T(0.0f)))));
-    assert(all(eq(T(0.0f), select(m3, T(1.0f), T(0.0f)))));
-}
-
 #if defined(ENOKI_X86_SSE42)
 ENOKI_TEST(test27_flush_denormals) {
     bool prev = flush_denormals();
@@ -497,3 +488,12 @@ ENOKI_TEST(test27_flush_denormals) {
     set_flush_denormals(prev);
 }
 #endif
+
+ENOKI_TEST_ALL(test28_mask_from_int) {
+    mask_t<T> m1(true), m2(true | true), m3(true & false);
+    assert(all_nested(m1) && all_nested(m2) && none_nested(m3));
+    assert(all_nested(eq(m1, m2)) && none_nested(eq(m2, m3)));
+    assert(all(eq(T(1.0f), select(m1, T(1.0f), T(0.0f)))));
+    assert(all(eq(T(1.0f), select(m2, T(1.0f), T(0.0f)))));
+    assert(all(eq(T(0.0f), select(m3, T(1.0f), T(0.0f)))));
+}


### PR DESCRIPTION
Requires #6.

This is intended to cover a common use-case in Mitsuba2:

```cpp
using ObjectPtr = Array<Object *, PacketSize>;
using EmitterPtr = Array<Emitter *, PacketSize>;
void my_function(ObjectPtr objects) {
    auto emitters = enoki::reinterpret_array<EmitterPtr>(objects);
    // (...)
}
```

The new test is currently failing, due to (it seems) a weird behavior in mask equality check, which I will investigate soon.