### PR TITLE
arithmetic involving arrays of pointers

### DIFF
--- a/include/enoki/array_generic.h
+++ b/include/enoki/array_generic.h
@@ -418,7 +418,7 @@ public:
     ENOKI_INLINE auto add_(const Derived &d) const {
         expr_t<Derived> result;
         ENOKI_CHKSCALAR for (size_t i = 0; i < Size; ++i)
-            result.coeff(i) = coeff(i) + d.coeff(i);
+            (Value &) result.coeff(i) = (const Value &) coeff(i) + (const Value &) d.coeff(i);
         return result;
     }
 
@@ -426,7 +426,7 @@ public:
     ENOKI_INLINE auto sub_(const Derived &d) const {
         expr_t<Derived> result;
         ENOKI_CHKSCALAR for (size_t i = 0; i < Size; ++i)
-            result.coeff(i) = coeff(i) - d.coeff(i);
+            (Value &) result.coeff(i) = (const Value &) coeff(i) - (const Value &) d.coeff(i);
         return result;
     }
 

--- a/include/enoki/morton.h
+++ b/include/enoki/morton.h
@@ -46,10 +46,6 @@ template <typename Value> constexpr Value morton_magic(size_t dim, size_t level)
     return value;
 }
 
-constexpr size_t clog2i(size_t value) {
-    return (value > 1) ? 1 + clog2i(value >> 1) : 0;
-}
-
 /// Bit scatter function. \c Dimension defines the final distance between two output bits
 template <size_t, typename Value, size_t Level,
           std::enable_if_t<Level == 0, int> = 0>

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -497,3 +497,48 @@ ENOKI_TEST(test27_flush_denormals) {
     set_flush_denormals(prev);
 }
 #endif
+
+ENOKI_TEST_ALL(test28_pointer_arithmetic) {
+    {
+        /* Power of two sized instance */
+        struct Class { uint32_t x;};
+        using ClassP = Packet<Class*, Size>;
+        using UInt32P = Packet<uint32_t, Size>;
+
+        Class *a = (Class *) 0x1234;
+        ClassP x(a), y(x);
+
+        assert(x-x == 0);
+        assert(a-x == 0);
+        y += 1;
+        assert(y == a + UInt32P(1));
+        assert(x != y);
+        assert(y-x == 1);
+        assert((uintptr_t) y.coeff(0) - (uintptr_t) x.coeff(0) == sizeof(Class));
+        y -= UInt32P(1);
+        assert(x == y);
+
+        Class z; z.x = 0; /* Quench warnings */
+    }
+    {
+        /* Non-power of two sized instance */
+        struct Class { uint32_t x[3];};
+        using ClassP = Packet<Class*, Size>;
+        using UInt32P = Packet<uint32_t, Size>;
+
+        Class *a = (Class *) 0x1234;
+        ClassP x(a), y(x);
+
+        assert(x-x == 0);
+        assert(a-x == 0);
+        y += 1;
+        assert(y == a + UInt32P(1));
+        assert(x != y);
+        assert(y-x == 1);
+        assert((uintptr_t) y.coeff(0) - (uintptr_t) x.coeff(0) == sizeof(Class));
+        y -= UInt32P(1);
+        assert(x == y);
+
+        Class z; z.x[0] =0; /* Quench warnings */
+    }
+}


### PR DESCRIPTION
This commit extends Enoki with the ability to add/subtract an integer
to/from an Enoki pointer array. The operation has the same semantics as
in C: specifically, the integer amount is scaled by the size of the
underlying type.

Taking differences between two pointers arrays returns an integer array,
whose entries represent the pointer difference divided by the size of
the underlying type.