### PR TITLE
`pow(x, y)` with negative `x` returns NaN

### DIFF
--- a/tests/explog.cpp
+++ b/tests/explog.cpp
@@ -95,4 +95,8 @@ ENOKI_TEST_FLOAT(test04_log) {
 ENOKI_TEST_FLOAT(test05_pow) {
     assert(T(abs(pow(T(Value(M_PI)), T(Value(-2))) -
                T(Value(0.101321183642338))))[0] < 1e-6f);
+    assert(T(abs(pow(T(Value(-1.0)), T(Value(2))) -
+               T(Value(1.0))))[0] < 1e-6f);
+    assert(T(abs(pow(T(Value(-M_PI)), T(Value(2))) -
+               T(Value(9.869604401))))[0] < 1e-6f);
 }


### PR DESCRIPTION
In approximate mode, `pow` is computed as:

https://github.com/mitsuba-renderer/enoki/blob/364f6f7d308ffe347bea39ac616d8c8e7fb43ef1/include/enoki/array_base.h#L1481-L1492

which doesn't allow for negative `x` values.