### PR TITLE
Fix for DynamicArray<PacketMask>::zero_

### DIFF
--- a/include/enoki/array_dynamic.h
+++ b/include/enoki/array_dynamic.h
@@ -680,7 +680,8 @@ struct DynamicArrayImpl : DynamicArrayBase<Packet_, Derived_> {
     // -----------------------------------------------------------------------
 
     static Derived zero_(size_t size) {
-        Derived result(zero<Value>(), size);
+        using Underlying = std::conditional_t<IsMask, bool, Value>;
+        Derived result(zero<Underlying>(), size);
         return result;
     }
 


### PR DESCRIPTION
This PR enables usage of `zero<DynamicArray<PacketMask<float, ...>>>`.

Without the fix, we have `DynamicArray<PacketMask<float, ...>>::Value == float`, which means that:

https://github.com/mitsuba-renderer/enoki/blob/94b7787d502750185aecf2d517233e2718e2ae6b/include/enoki/array_dynamic.h#L682-L685

...cannot use the `(value, size)` constructor that's intended for masks:

https://github.com/mitsuba-renderer/enoki/blob/94b7787d502750185aecf2d517233e2718e2ae6b/include/enoki/array_dynamic.h#L254-L259

With the fix, we pass-in `zero<bool>()` instead of `zero<float>()`.

Note that I am not sure whether this implementation handles recursion (nested Mask / Arrays) well.

---

For context, this fix allows us to finally bind slicing operators for `PositionSample3fX` and `DirectionSample3fX` in Mitsuba2 (they have a `Mask` field that needs to be constructed with `zero<...>`).