### PR TITLE
Behavior of `packet(DynamicArray, i)`

### DIFF
--- a/docs/dynamic.rst
+++ b/docs/dynamic.rst
@@ -201,23 +201,23 @@ Accessing array packets
 The :cpp:func:`enoki::packet` function can be used to create a reference to the
 :math:`i`-th packet of a dynamic array or a custom dynamic data structure.
 For instance, the following code iterates over all packets and resets their
-time values
+time values:
 
 .. code-block:: cpp
 
     /* Reset the time value of all records */
     for (size_t i = 0; i < packets(coord); ++i) {
-        auto ref = packet(coord, n);
+        auto &&ref = packet(coord, n);
         ref.time = 0;
     }
 
-The ``packet()`` function is interesting because it returns an instance of a
-new type ``GPSRecord2<FloatP&>`` that was not discussed yet (note the ampersand
-in the template argument). Instead of directly storing data, all of fields of a
-``GPSRecord2<FloatP&>`` are references pointing to packets of data elsewhere in
-memory. In this case, overwriting a field of this structure of references will
-change the corresponding entry *of the dynamic array*. Conceptually, this looks
-as follows:
+When used with a dynamic data structure, ``packet()`` function is interesting
+because it returns an instance of a new type ``GPSRecord2<FloatP&>`` that was
+not discussed yet (note the ampersand in the template argument). Instead of
+directly storing data, all fields of a ``GPSRecord2<FloatP&>`` are references
+pointing to packets of data elsewhere in memory. In this case, assigning
+(writing) to a field of this structure of references will change the
+corresponding entry *of the dynamic array*. Conceptually, this looks as follows:
 
 .. image:: dynamic-03.svg
     :width: 600px
@@ -232,6 +232,21 @@ References can also be cast into their associated packet types and vice versa:
 
     /* Assign a GPSRecord2<FloatP> to a GPSRecord2<FloatP&> */
     packet(coord, n + 1) = cp;
+
+.. note::
+
+    For non-nested dynamic arrays such as ``FloatX = DynamicArray<FloatP>``,
+    calling ``packet()`` simply returns a reference to the right ``FloatP``
+    entry in that array of packets. Note this is a reference type
+    (``FloatP&``), not a structure (``GPSRecord2<FloatP&>``).
+    This is why we strongly encourage using universal references (``auto &&``)
+    to hold the result of ``packet()``:
+
+    .. code-block:: cpp
+
+        auto   ref = packet(coord, i);   // Only works for dynamic structures
+        auto  &ref = packet(numbers, i); // Only works for non-nested arrays
+        auto &&ref = packet(coord, i);   // Works for both
 
 Accessing array slices
 ----------------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1683,7 +1683,7 @@ Miscellaneous operations
             // ...
         }
 
-    which will generate indices `(0, 0, 0)`, `(0, 0, 1)`, etc. As before, the
+    which will generate indices ``(0, 0, 0)``, ``(0, 0, 1)``, etc. As before, the
     last loop iteration will generally have several disabled entries.
 
 


### PR DESCRIPTION
The [doc](https://enoki.readthedocs.io/en/master/dynamic.html#accessing-array-packets) presents usage of `packet` as follows:

```c++
/* Reset the time value of all records */
for (size_t i = 0; i < packets(coord); ++i) {
    auto ref = packet(coord, n);
    ref.time = 0;
}
```

But for simple (non-struct) types, the following does not assign to the original dynamic array entries, but to a copy of packet `i`:

```c++
for (size_t i = 0; i < packets(array); ++i) {
    auto a = packet(array, i);
    auto m = packet(mask, i);
    a = T(i);
    m = (a > 0);
}
```

Is it intended behavior? If so, should we update the doc to recommend using `auto &ref = packet(...)`?  (+ warn against using `auto` alone)

**Edit**: the issue with my proposition is that `auto &` is not valid when calling `packet(struct, i)`:

```c++
../src/integrators/path_wavefront.cpp:127:23: error: non-const lvalue reference to type 'Spectrum<...>' cannot bind to a temporary of type 'Spectrum<...>'
                auto &throughput = packet(ctx.throughput, j);
                      ^            ~~~~~~~~~~~~~~~~~~~~~~~~~
```

I hope there's a solution, it'd be very error-prone to get the `&` right depending on the value type of the dynamic array.