### PR TITLE
Matrix identity: fix scalar type

### DIFF
--- a/include/enoki/matrix.h
+++ b/include/enoki/matrix.h
@@ -222,7 +222,7 @@ template <typename T, enable_if_matrix_t<T> = 0>
 ENOKI_INLINE T identity(size_t size = 1) {
     T result = zero<T>(size);
     for (size_t i = 0; i < T::Size; ++i)
-        result(i, i) = full<typename T::Entry>(1.f, size);
+        result(i, i) = full<typename T::Entry>(scalar_t<T>(1.f), size);
     return result;
 }
 


### PR DESCRIPTION
The right-hand side could generate e.g. an `enoki::Packet<float, 16, true, enoki::RoundingMode::Default>` even though the left-hand side was `enoki::Packet<double, 16, true, enoki::RoundingMode::Default>`.
Which would in turn break compilation of Mitsuba 2 in debug mode (at least on my branch).