### PR TITLE
Fix CMAKE_CUDA_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(ENOKI_PYTHON   "Build pybind11 interface to CUDA & automatic differentiat
 
 if (ENOKI_CUDA)
   set(ENOKI_CUDA_COMPUTE_CAPABILITY "61" CACHE STRING "Compute capability as specified by https://developer.nvidia.com/cuda-gpus")
-  set(CMAKE_CUDA_FLAGS "-gencode arch=compute_${ENOKI_CUDA_COMPUTE_CAPABILITY},code=compute_${ENOKI_CUDA_COMPUTE_CAPABILITY} --cudart shared -Xcompiler -march=native -Xcompiler -fvisibility=hidden")
+  set(CMAKE_CUDA_FLAGS "-gencode arch=compute_${ENOKI_CUDA_COMPUTE_CAPABILITY},code=compute_${ENOKI_CUDA_COMPUTE_CAPABILITY} -cudart shared -Xcompiler -march=native -Xcompiler -fvisibility=hidden")
   project(enoki CXX CUDA)
   add_definitions(-DENOKI_BUILD_CUDA=1)
 else()


### PR DESCRIPTION
When using a double hyphen to specify the cudart flag for CUDA, I get the following error in CMakeTestCUDACompiler:

    nvcc fatal   : redefinition of argument 'cudart'

This seems to be because the tests adds "-cudart' if it does not already sees it in flags, hence leading to a command line with both "--cudart" and "-cudart". I hope there is not the inverse behavior on some other setups.