### PR TITLE
Fix regression in `set_gradient` binding + add basic unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ Makefile
 *.ninja
 
 # Miscellaneous;
-/build
+/build*
 /Testing
 /tests/Testing
 *.dir

--- a/docs/autodiff.rst
+++ b/docs/autodiff.rst
@@ -469,7 +469,7 @@ used in the example.
             def backward(ctx, grad_out):
                 # Attach gradients received from PyTorch to the output
                 # variable of the forward pass
-                enoki.set_gradient(ctx.out, enoki.FloatD(grad_out))
+                enoki.set_gradient(ctx.out, enoki.FloatC(grad_out))
 
                 # Perform a reverse-mode traversal. Note that the static
                 # version of the backward() function is being used, see

--- a/src/python/common.h
+++ b/src/python/common.h
@@ -464,12 +464,13 @@ py::class_<Array> bind(py::module &m, const char *name) {
         m.def("set_requires_gradient",
               [](Array &a, bool value) { set_requires_gradient(a, value); },
               "array"_a, "value"_a = true);
+        m.def("detach", [](const Matrix4fD &a) { return eval(detach(a)); });
 
         m.def("gradient", [](Array &a) -> Detached { return gradient(a); });
         m.def("gradient_index", [](Array &a) { return gradient_index(a); });
 
         m.def("set_gradient",
-              [](Array &a, const Detached &g, bool backward) { set_gradient(a, g, backward); },
+              [](Array &a, const Array &g, bool backward) { set_gradient(a, detach(g), backward); },
               "array"_a, "gradient"_a, "backward"_a = true);
 
         m.def("graphviz", [](const Array &a) { return graphviz(a); });

--- a/src/python/common.h
+++ b/src/python/common.h
@@ -464,7 +464,6 @@ py::class_<Array> bind(py::module &m, const char *name) {
         m.def("set_requires_gradient",
               [](Array &a, bool value) { set_requires_gradient(a, value); },
               "array"_a, "value"_a = true);
-        m.def("detach", [](const Matrix4fD &a) { return eval(detach(a)); });
 
         m.def("gradient", [](Array &a) -> Detached { return gradient(a); });
         m.def("gradient_index", [](Array &a) { return gradient_index(a); });

--- a/src/python/common.h
+++ b/src/python/common.h
@@ -469,7 +469,7 @@ py::class_<Array> bind(py::module &m, const char *name) {
         m.def("gradient_index", [](Array &a) { return gradient_index(a); });
 
         m.def("set_gradient",
-              [](Array &a, const Array &g, bool backward) { set_gradient(a, detach(g), backward); },
+              [](Array &a, const Detached &g, bool backward) { set_gradient(a, g, backward); },
               "array"_a, "gradient"_a, "backward"_a = true);
 
         m.def("graphviz", [](const Array &a) { return graphviz(a); });

--- a/tests/python/test_pytorch.py
+++ b/tests/python/test_pytorch.py
@@ -1,7 +1,7 @@
 import enoki as ek
 import numpy as np
+import pytest
 import torch
-
 
 class EnokiAtan2(torch.autograd.Function):
     """PyTorch function example from the documentation."""
@@ -18,7 +18,7 @@ class EnokiAtan2(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_out):
-        ek.set_gradient(ctx.out, ek.FloatD(grad_out))
+        ek.set_gradient(ctx.out, ek.FloatC(grad_out))
         ek.FloatD.backward()
         result = (ek.gradient(ctx.in1).torch()
                   if ek.requires_gradient(ctx.in1) else None,
@@ -32,7 +32,12 @@ class EnokiAtan2(torch.autograd.Function):
 def test01_set_gradient():
     a = ek.FloatD(42, 10)
     ek.set_requires_gradient(a)
-    grad = ek.FloatD(-1, 10)
+
+    with pytest.raises(TypeError):
+        grad = ek.FloatD(-1, 10)
+        ek.set_gradient(a, grad)
+
+    grad = ek.FloatC(-1, 10)
     ek.set_gradient(a, grad)
     assert np.allclose(grad.numpy(), ek.gradient(a).numpy())
 

--- a/tests/python/test_pytorch.py
+++ b/tests/python/test_pytorch.py
@@ -1,0 +1,53 @@
+import enoki as ek
+import numpy as np
+import torch
+
+
+class EnokiAtan2(torch.autograd.Function):
+    """PyTorch function example from the documentation."""
+    @staticmethod
+    def forward(ctx, arg1, arg2):
+        ctx.in1 = ek.FloatD(arg1)
+        ctx.in2 = ek.FloatD(arg2)
+        ek.set_requires_gradient(ctx.in1, arg1.requires_grad)
+        ek.set_requires_gradient(ctx.in2, arg2.requires_grad)
+        ctx.out = ek.atan2(ctx.in1, ctx.in2)
+        out_torch = ctx.out.torch()
+        ek.cuda_malloc_trim()
+        return out_torch
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        ek.set_gradient(ctx.out, ek.FloatD(grad_out))
+        ek.FloatD.backward()
+        result = (ek.gradient(ctx.in1).torch()
+                  if ek.requires_gradient(ctx.in1) else None,
+                  ek.gradient(ctx.in2).torch()
+                  if ek.requires_gradient(ctx.in2) else None)
+        del ctx.out, ctx.in1, ctx.in2
+        ek.cuda_malloc_trim()
+        return result
+
+
+def test01_array_to_torch():
+    a = ek.FloatD(42, 10)
+    a_torch = a.torch()
+    assert isinstance(a_torch, torch.Tensor)
+    a_torch += 8
+    a_np = a_torch.cpu().numpy()
+    assert isinstance(a_np, np.ndarray)
+    assert np.allclose(a_np, 50)
+
+
+def test02_pytorch_function():
+    enoki_atan2 = EnokiAtan2.apply
+
+    y = torch.tensor(1.0, device='cuda')
+    x = torch.tensor(2.0, device='cuda')
+    y.requires_grad_()
+    x.requires_grad_()
+
+    o = enoki_atan2(y, x)
+    o.backward()
+    assert np.allclose(y.grad.cpu(), 0.4)
+    assert np.allclose(x.grad.cpu(), -0.2)

--- a/tests/python/test_pytorch.py
+++ b/tests/python/test_pytorch.py
@@ -29,7 +29,20 @@ class EnokiAtan2(torch.autograd.Function):
         return result
 
 
-def test01_array_to_torch():
+def test01_set_gradient():
+    a = ek.FloatD(42, 10)
+    ek.set_requires_gradient(a)
+    grad = ek.FloatD(-1, 10)
+    ek.set_gradient(a, grad)
+    assert np.allclose(grad.numpy(), ek.gradient(a).numpy())
+
+    # Note: if `backward` is not called here, test03 segfaults later.
+    # TODO: we should not need this, there's most likely some missing cleanup when `a` is destructed
+    ek.FloatD.backward()
+    del a, grad
+
+
+def test02_array_to_torch():
     a = ek.FloatD(42, 10)
     a_torch = a.torch()
     assert isinstance(a_torch, torch.Tensor)
@@ -39,7 +52,7 @@ def test01_array_to_torch():
     assert np.allclose(a_np, 50)
 
 
-def test02_pytorch_function():
+def test03_pytorch_function():
     enoki_atan2 = EnokiAtan2.apply
 
     y = torch.tensor(1.0, device='cuda')


### PR DESCRIPTION
On `master`, using `set_gradient` from the bindings causes a segfault. This PR reverts a change that caused this regression, and adds a few basic unit tests covering the usage of `set_gradient` that failed + the PyTorch example from the documentation.

Note that writing these tests uncovered another issue, which we could try to fix in this PR as well: if a graph is constructed in `test01` but not cleared (with a call to `backward`), the next call to `backward` segfaults in `test03`. This hints at a potential missing cleanup of the previous graph when variable `a` goes out of scope.