### PR TITLE
Fix dllimport qualifiers for dynamic arrays used with autodiff

### DIFF
--- a/include/enoki/dynamic.h
+++ b/include/enoki/dynamic.h
@@ -1131,11 +1131,11 @@ auto vectorize_wrapper(Return (Class::*f)(Arg...) const) {
 }
 
 #if defined(ENOKI_AUTODIFF_H) && !defined(ENOKI_BUILD)
-    extern ENOKI_IMPORT template struct Tape<DynamicArray<Packet<float>>>;
-    extern ENOKI_IMPORT template struct DiffArray<DynamicArray<Packet<float>>>;
+    ENOKI_AUTODIFF_EXTERN template struct ENOKI_AUTODIFF_EXPORT Tape<DynamicArray<Packet<float>>>;
+    ENOKI_AUTODIFF_EXTERN template struct ENOKI_AUTODIFF_EXPORT DiffArray<DynamicArray<Packet<float>>>;
 
-    extern ENOKI_IMPORT template struct Tape<DynamicArray<Packet<double>>>;
-    extern ENOKI_IMPORT template struct DiffArray<DynamicArray<Packet<double>>>;
+    ENOKI_AUTODIFF_EXTERN template struct ENOKI_AUTODIFF_EXPORT Tape<DynamicArray<Packet<double>>>;
+    ENOKI_AUTODIFF_EXTERN template struct ENOKI_AUTODIFF_EXPORT DiffArray<DynamicArray<Packet<double>>>;
 #endif
 
 NAMESPACE_END(enoki)


### PR DESCRIPTION
It was failing with MSVC16 with a syntax error and this change just syncs with equivalent Tape implementations at the end of `autodiff.h`.