### PR TITLE
Build fix for Cuda 11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,9 @@ endif()
 add_definitions(-DENOKI_BUILD=1)
 
 if (ENOKI_CUDA)
-  include_directories(ext/cub)
+  if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11)
+    include_directories(ext/cub)
+  endif()
   set(CMAKE_SHARED_LINKER_FLAGS_BACKUP "${CMAKE_SHARED_LINKER_FLAGS}")
   string(REPLACE "-stdlib=libc++" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
   add_library(enoki-cuda SHARED


### PR DESCRIPTION
The `cub` library is now included in the main Cuda driver starting
with (major) version 11, causing incompatibility errors with the
`thrust` library.

This fix adds a version check for the Cuda compiler and only includes
`ext/cub` if we're using a version of Cuda earlier than 11.