### PR TITLE
C++ Version is Mismatched under VS2019 16.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,7 @@ if (ENOKI_CUDA)
       src/cuda/horiz.cu
       src/cuda/jit.cu
   )
+  set_property(TARGET enoki-cuda PROPERTY CXX_STANDARD 17)
   target_compile_definitions(enoki-cuda PRIVATE -DENOKI_CUDA_COMPUTE_CAPABILITY=${ENOKI_CUDA_COMPUTE_CAPABILITY} -DTHRUST_IGNORE_CUB_VERSION_CHECK)
   target_link_libraries(enoki-cuda PRIVATE cuda)
   message(STATUS "Enoki: building the CUDA backend.")


### PR DESCRIPTION
## Description

When enoki-cuda is included in the compilation, under VS2019, the C++ version flags for CUDA are set to -std=c++14 when they should be set to C++17. This PR fixes that issue by explicitly setting the `CXX_STANDARD` of `enoki-cuda` to `C++17`. 

Fixes/Related: #118 

## Testing

Code compiles successfully under Windows VS2019 16.10. No access to Linux for testing, but code passes all appveyor MSVC tests.