### PR TITLE
Fix compilability with /Zc:preprocessor

### DIFF
--- a/include/enoki/array_macro.h
+++ b/include/enoki/array_macro.h
@@ -30,7 +30,8 @@
 #define ENOKI_MAP_NEXT(test, next) ENOKI_MAP_NEXT_1(ENOKI_MAP_GET_END test, next)
 #define ENOKI_EXTRACT_0(next, ...) next
 
-#if defined(_MSC_VER) // MSVC is not as eager to expand macros, hence this workaround
+// Traditional MSVC preprocessor is not as eager to expand macros, hence this workaround
+#if defined(_MSC_VER) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
 #define ENOKI_MAP_EXPR_NEXT_1(test, next) \
     ENOKI_EVAL_0(ENOKI_MAP_NEXT_0(test, ENOKI_MAP_COMMA next, 0))
 #define ENOKI_MAP_STMT_NEXT_1(test, next) \


### PR DESCRIPTION
The code in array_macro.h assumed that definition of _MSC_VER macro implies that the traditional MSVC preprocessor is used.

This is not always the case. Since VS 2017 15.8 MSVC offers a new preprocessor which is standard conforming. The new mode is available with /Zc:preprocessor compiler option. Previously it was available with /experimental:preprocessor.

Availability of the new mode means that it is no longer enough to check only for the definition of _MSC_VER. One has to check the macro _MSVC_TRADITIONAL too.

This check is necessary since the macro that definitions of ENOKI_MAP_EXPR_NEXT_1 and ENOKI_MAP_STMT_NEXT_1 are otherwise incorrect and they don't work with standard conforming preprocessor.